### PR TITLE
Types metabox should say Job Types not Job Listings (#893)

### DIFF
--- a/includes/admin/class-wp-job-manager-writepanels.php
+++ b/includes/admin/class-wp-job-manager-writepanels.php
@@ -128,7 +128,8 @@ class WP_Job_Manager_Writepanels {
 			remove_meta_box( 'job_listing_typediv', 'job_listing', 'side');
 		} elseif ( false == job_manager_multi_job_type() ) {
 			remove_meta_box( 'job_listing_typediv', 'job_listing', 'side');
-			add_meta_box( 'job_listing_type', __( 'Job Listings', 'wp-job-manager' ), array( $this, 'job_listing_metabox' ),'job_listing' ,'side','core');
+			$job_listing_type = get_taxonomy( 'job_listing_type' );
+			add_meta_box( 'job_listing_type', $job_listing_type->labels->menu_name, array( $this, 'job_listing_metabox' ),'job_listing' ,'side','core');
 		}
 	}
 


### PR DESCRIPTION
* Types metabox should say Job Types not Job Listings

* use tax label for metabox title #795

* use menu_name instead of label for Job Types